### PR TITLE
feat: Add logo upload functionality for app title

### DIFF
--- a/app.py
+++ b/app.py
@@ -701,7 +701,7 @@ UPLOAD_FOLDER = 'uploads'
 if not os.path.exists(UPLOAD_FOLDER):
     os.makedirs(UPLOAD_FOLDER)
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024
+app.config['MAX_CONTENT_LENGTH'] = 1 * 1024 * 1024  # 1MB
 
 # 部屋ごとのCSVファイルを保存するフォルダ
 ROOM_CSV_FOLDER = 'room_csv'
@@ -10563,6 +10563,11 @@ def debug_image_upload():
         print(f"全般エラー: {e}")
         return f"❌ エラー: {e}"
     
+@app.errorhandler(413)
+def request_entity_too_large(error):
+    flash('アップロードされたファイルが大きすぎます。1MB以下のファイルを選択してください。', 'danger')
+    return redirect(request.url)
+
 @app.errorhandler(500)
 def internal_error(error):
     print(f"500 Error: {error}")

--- a/templates/admin_app_info.html
+++ b/templates/admin_app_info.html
@@ -88,7 +88,7 @@
                                    id="logo_image"
                                    name="logo_image"
                                    class="form-control">
-                            <div class="form-text">推奨サイズ: 120x40ピクセル</div>
+                            <div class="form-text">1MB以下の画像（推奨: 横長、高さ40px程度）</div>
                             {% if app_info.logo_image_filename %}
                             <div class="mt-2">
                                 <img src="{{ url_for('static', filename='uploads/logos/' + app_info.logo_image_filename) }}" alt="現在のロゴ" style="max-height: 40px; background-color: #f8f9fa; padding: 5px; border-radius: 5px;">

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,10 +34,11 @@
         <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm rounded mb-4">
             <div class="container-fluid">
                 <a class="navbar-brand fw-bold text-primary" href="{{ url_for('index') }}">
+                    <i class="fas fa-book-open me-2"></i>
                     {% if app_info and app_info.logo_type == 'image' and app_info.logo_image_filename %}
-                        <img src="{{ url_for('static', filename='uploads/logos/' + app_info.logo_image_filename) }}" alt="{{ app_info.app_name }} Logo" style="max-height: 40px;">
+                        <img src="{{ url_for('static', filename='uploads/logos/' + app_info.logo_image_filename) }}" alt="{{ app_info.app_name }} Logo" style="max-height: 24px; vertical-align: middle;">
                     {% else %}
-                        <i class="fas fa-book-open me-2"></i>{{ app_name }}
+                        {{ app_name }}
                     {% endif %}
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
This commit introduces the ability for administrators to replace the text-based application title with a custom logo image. The book icon remains unchanged.

- The `AppInfo` model in `app.py` has been extended with `logo_type` and `logo_image_filename` columns.
- The `migrate_database` function has been updated to add the new columns.
- The admin page (`templates/admin_app_info.html`) now features controls to switch between a text title and an image logo, with a file upload field that appears conditionally.
- The help text in the admin UI has been updated to include a 1MB file size limit and recommended dimensions.
- The backend logic in `app.py` now handles logo image uploads, saving files to `static/uploads/logos/` and cleaning up old files.
- A `MAX_CONTENT_LENGTH` of 1MB is now enforced in the app configuration, and a corresponding error handler has been added to inform users if an upload is too large.
- The main layout (`templates/base.html`) has been updated to conditionally display the uploaded logo next to the book icon, replacing the standard text title.