### PR TITLE
Fix: Add gunicorn to requirements.txt for deployment.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ SQLAlchemy==2.0.25
 # その他
 cryptography==41.0.7
 Pillow==10.1.0
+gunicorn


### PR DESCRIPTION
The previous deployment failed because the `gunicorn` command was not found. This was due to the `gunicorn` package being missing from the `requirements.txt` file.

This commit adds `gunicorn` to the requirements to ensure the production web server can start correctly.