### PR TITLE
Fix: Add psycopg2-binary to requirements.txt for PostgreSQL support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pytz==2024.1
 SQLAlchemy==2.0.25
 
 # PostgreSQL対応
+psycopg2-binary
 
 # その他
 cryptography==41.0.7


### PR DESCRIPTION
The deployment was failing with a `ModuleNotFoundError: No module named 'psycopg2'`. This indicates that the application, when deployed to a production environment using PostgreSQL, was missing the required database driver.

This commit adds `psycopg2-binary` to `requirements.txt` to ensure the driver is installed during the build process, allowing the application to connect to the database.